### PR TITLE
Release 2.1.0 (Upgraded dependencies)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.1.0
+- Change minimum required flutter sdk to `3.2.3`.
+- Change dartfmt to dart format.
+- Change dartanalyzer to dart analyzer.
+- Change test_coverage to coverage.
+- Fixed all lint warnings.
+- Upgrade all dev dependencies.
+
 ## 2.0.0
 
 - Add NNBD support.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,7 @@
 include: package:very_good_analysis/analysis_options.yaml
+
+analyzer:
+  exclude: [lib/**/hepburn.dart]
 # linter:
 #   rules:
 #     await_only_futures: true

--- a/lib/kana_kit.dart
+++ b/lib/kana_kit.dart
@@ -11,6 +11,8 @@ export 'src/models/models.dart';
 part 'src/conversions.dart';
 part 'src/checks.dart';
 
+const _cannotBeEmptyWarning = 'The input String cannot be empty.';
+
 /// {@template kana_kit}
 /// A Dart library for handling and converting Japanese characters such as
 /// hiragana, katakana and kanji.
@@ -50,7 +52,7 @@ class KanaKit {
   /// isRomaji('a！b&cーd'); // false (zenkaku punctuation is not allowed)
   /// ```
   bool isRomaji(String input) {
-    assert(input.isNotEmpty);
+    assert(input.isNotEmpty, _cannotBeEmptyWarning);
 
     return input.chars.every(_isCharRomaji);
   }
@@ -68,7 +70,7 @@ class KanaKit {
   /// isJapanese('A泣き虫'); // false
   /// ```
   bool isJapanese(String input) {
-    assert(input.isNotEmpty);
+    assert(input.isNotEmpty, _cannotBeEmptyWarning);
 
     return input.chars.every(_isCharJapanese);
   }
@@ -85,7 +87,7 @@ class KanaKit {
   /// isKana('あAア'); // false
   /// ```
   bool isKana(String input) {
-    assert(input.isNotEmpty);
+    assert(input.isNotEmpty, _cannotBeEmptyWarning);
 
     return input.chars.every(_isCharKana);
   }
@@ -100,7 +102,7 @@ class KanaKit {
   /// isHiragana('あア'); // false
   /// ```
   bool isHiragana(String input) {
-    assert(input.isNotEmpty);
+    assert(input.isNotEmpty, _cannotBeEmptyWarning);
 
     return input.chars.every(_isCharHiragana);
   }
@@ -116,7 +118,7 @@ class KanaKit {
   /// isKatakana('あア'); // false
   /// ```
   bool isKatakana(String input) {
-    assert(input.isNotEmpty);
+    assert(input.isNotEmpty, _cannotBeEmptyWarning);
 
     return input.chars.every(_isCharKatakana);
   }
@@ -133,7 +135,7 @@ class KanaKit {
   /// isKanji('🐸'); // false
   /// ```
   bool isKanji(String input) {
-    assert(input.isNotEmpty);
+    assert(input.isNotEmpty, _cannotBeEmptyWarning);
 
     return input.chars.every(_isCharKanji);
   }
@@ -153,13 +155,13 @@ class KanaKit {
   /// isMixed('あア'); // false
   /// ```
   bool isMixed(String input) {
-    assert(input.isNotEmpty);
+    assert(input.isNotEmpty, _cannotBeEmptyWarning);
 
     final chars = input.chars;
 
     final hasRomaji = chars.any(_isCharRomaji);
     final hasKana = chars.any(_isCharHiragana) || chars.any(_isCharKatakana);
-    final hasKanji = !(!config.passKanji ? chars.any(_isCharKanji) : false);
+    final hasKanji = config.passKanji || !chars.any(_isCharKanji);
 
     return hasKana && hasRomaji && hasKanji;
   }

--- a/lib/src/checks.dart
+++ b/lib/src/checks.dart
@@ -1,18 +1,20 @@
 part of '../kana_kit.dart';
 
+const _charSingleDigitWarning = 'char must be a single character';
+
 bool _isCharInRange(
   String char, {
   required int start,
   required int end,
 }) {
-  assert(char.length == 1);
+  assert(char.length == 1, _charSingleDigitWarning);
 
   final code = char.code;
   return start <= code && code <= end;
 }
 
 bool _isCharHiragana(String char) {
-  assert(char.length == 1);
+  assert(char.length == 1, _charSingleDigitWarning);
 
   return _isCharLongDash(char) ||
       _isCharInRange(
@@ -23,7 +25,7 @@ bool _isCharHiragana(String char) {
 }
 
 bool _isCharKatakana(String char) {
-  assert(char.length == 1);
+  assert(char.length == 1, _charSingleDigitWarning);
 
   return _isCharInRange(
     char,
@@ -33,7 +35,7 @@ bool _isCharKatakana(String char) {
 }
 
 bool _isCharKanji(String char) {
-  assert(char.length == 1);
+  assert(char.length == 1, _charSingleDigitWarning);
 
   return _isCharInRange(
     char,
@@ -43,7 +45,7 @@ bool _isCharKanji(String char) {
 }
 
 bool _isCharUpperCase(String char) {
-  assert(char.length == 1);
+  assert(char.length == 1, _charSingleDigitWarning);
 
   return _isCharInRange(
     char,
@@ -53,25 +55,25 @@ bool _isCharUpperCase(String char) {
 }
 
 bool _isCharKana(String char) {
-  assert(char.length == 1);
+  assert(char.length == 1, _charSingleDigitWarning);
 
   return _isCharHiragana(char) || _isCharKatakana(char);
 }
 
 bool _isCharLongDash(String char) {
-  assert(char.length == 1);
+  assert(char.length == 1, _charSingleDigitWarning);
 
   return char.code == prolongedSoundMark;
 }
 
 bool _isCharSlashDot(String char) {
-  assert(char.length == 1);
+  assert(char.length == 1, _charSingleDigitWarning);
 
   return char.code == kanaSlashDot;
 }
 
 bool _isCharRomaji(String char) {
-  assert(char.length == 1);
+  assert(char.length == 1, _charSingleDigitWarning);
 
   return romajiRanges.any((range) {
     return _isCharInRange(char, start: range.left, end: range.right);
@@ -79,7 +81,7 @@ bool _isCharRomaji(String char) {
 }
 
 bool _isCharEnglishPunctuation(String char) {
-  assert(char.length == 1);
+  assert(char.length == 1, _charSingleDigitWarning);
 
   return enPunctuationRanges.any((range) {
     return _isCharInRange(char, start: range.left, end: range.right);
@@ -87,7 +89,7 @@ bool _isCharEnglishPunctuation(String char) {
 }
 
 bool _isCharJapanese(String char) {
-  assert(char.length == 1);
+  assert(char.length == 1, _charSingleDigitWarning);
 
   return japaneseRanges.any((range) {
     return _isCharInRange(char, start: range.left, end: range.right);

--- a/lib/src/conversions.dart
+++ b/lib/src/conversions.dart
@@ -7,20 +7,17 @@ String _katakanaToHiragana(
   bool destinationIsRomaji = false,
 }) {
   bool isCharInitialLongDash(String char, int index) {
-    assert(char.length == 1);
-
+    assert(char.length == 1, _charSingleDigitWarning);
     return _isCharLongDash(char) && index == 0;
   }
 
   bool isCharInnerLongDash(String char, int index) {
-    assert(char.length == 1);
-
+    assert(char.length == 1, _charSingleDigitWarning);
     return _isCharLongDash(char) && index > 0;
   }
 
   bool isKanaAsSymbol(String char) {
-    assert(char.length == 1);
-
+    assert(char.length == 1, _charSingleDigitWarning);
     return ['ヶ', 'ヵ'].contains(char);
   }
 
@@ -146,7 +143,10 @@ class _MappingParser {
     }
     // If the next child node does not have a node value, set its node value to
     // the input.
-    return {'': tree[''] + nextChar, ...tree[nextChar]};
+    final rootNode = tree[''] as String? ?? '';
+    final updatedRootNode = rootNode + nextChar;
+    final nextSubtree = tree[nextChar] as Map<String, dynamic>?;
+    return {'': updatedRootNode, ...nextSubtree ?? {}};
   }
 
   List<_CharacterConversionToken> _newChunk(
@@ -155,9 +155,9 @@ class _MappingParser {
   ) {
     // Start parsing a new chunk.
     final firstChar = remaining.chars.first;
-
+    final firstCharNode = root[firstChar] as Map<String, dynamic>?;
     return _parse(
-      tree: {'': firstChar, ...(root[firstChar] ?? {})},
+      tree: {'': firstChar, ...firstCharNode ?? {}},
       remaining: remaining.substring(1),
       lastCursor: currentCursor,
       currentCursor: currentCursor + 1,

--- a/lib/src/models/kana_kit_config.dart
+++ b/lib/src/models/kana_kit_config.dart
@@ -15,7 +15,8 @@ class KanaKitConfig extends Equatable {
     required this.passRomaji,
     required this.passKanji,
     required this.upcaseKatakana,
-  }) : romanization = Romanization.hepburn;
+    this.romanization = Romanization.hepburn,
+  });
 
   /// The default config for `KanaKit`.
   ///

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,386 +5,393 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "36a321c3d2cbe01cbcb3540a87b8843846e0206df3e691fa7b23e19e78de6d49"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "65.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: dfe03b90ec022450e22513b5e5ca1f01c0c01de9c3fba2f7fd233cb57a6b9a07
+      url: "https://pub.dev"
     source: hosted
-    version: "0.39.14"
+    version: "6.3.0"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "2.4.2"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "5bbf32bc9e518d41ec49718e2931cd4527292c9b0c6d2dffcf7fe6b9a8a8cf72"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.dartlang.org"
+      sha256: "8e36feea6de5ea69f2199f29cf42a450a855738c498b57c0b980e2d3cca9c362"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.4"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "3.1.1"
   coverage:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "8acabb8306b57a409bf4c83522065672ee13179297a6bb0cb9ead73948df7c76"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.14.2"
+    version: "1.7.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.1"
+    version: "3.0.3"
   equatable:
     dependency: "direct main"
     description:
       name: equatable
-      url: "https://pub.dartlang.org"
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.5"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.4"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0+3"
+    version: "2.1.2"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.3.4"
+    version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "4186c61b32f99e60f011f7160e32c89a758ae9b1d0c6d28e2c02ef0382300e2b"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
-  json_annotation:
-    dependency: transitive
-    description:
-      name: json_annotation
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.1"
-  lcov:
-    dependency: transitive
-    description:
-      name: lcov
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "5.7.0"
+    version: "0.7.0"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.11.4"
+    version: "1.2.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.16+1"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
-    version: "0.9.6+3"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
+    version: "1.0.4"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.4.12"
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.3"
+    version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "2ad4cddff7f5cc0e2d13069f2a3f7a73ca18f66abd6f5ecf215219cdb3638edb"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.0"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "05955e3de2683e1746222efd14b775df7131139e07695dc8e24650f6b4204504"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.4.4"
+    version: "2.1.4"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "1.4.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.8"
+    version: "1.1.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.3"
+    version: "1.0.4"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "8c463326277f68a628abab20580047b419c2ff66756fd0affd451f73f9508c11"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "52de2200bb098de739794c82d09c41ac27b2e42fd7e23cce7b9c74bf653c7296"
+      url: "https://pub.dev"
     source: hosted
     version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: d5f89a9e52b36240a80282b3dc0667dd36e53459717bb17b8fb102d30496606a
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: f8d9f247e2f9f90e32d1495ff32dac7e4ae34ffa7194c5ff8fcc0fd0e52df774
+      url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: db47e4797198ee601990820437179bb90219f918962318d494ada2b4b11e6f6d
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: dd11571b8a03f7cadcf91ec26a77e02bfbd6bbba2a512924d3116646b4198fc4
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a88162591b02c1f3a3db3af8ce1ea2b374bd75a7bb8d5e353bcfbdc79d719830
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: "694c108e13c6b35b15fcb0f8f03eddf8373f93b044c9497b5e81ce09f7381bda"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.5"
+    version: "1.25.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.19"
+    version: "0.7.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "2bc4b4ecddd75309300d8096f781c0e3280ca1ef85beda558d33fcbedc2eead4"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.3.15"
-  test_coverage:
-    dependency: "direct dev"
-    description:
-      name: test_coverage
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.0"
+    version: "0.6.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   very_good_analysis:
     dependency: "direct dev"
     description:
       name: very_good_analysis
-      url: "https://pub.dartlang.org"
+      sha256: "9ae7f3a3bd5764fb021b335ca28a34f040cd0ab6eec00a1b213b445dae58a4b8"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "5.1.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: a2662fb1f114f4296cf3f5a50786a2d888268d7776cf681aa17d660ffa23b246
+      url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "14.0.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.9.7+15"
+    version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "4188706108906f002b3a293509234588823c8c979dc83304e229ff400c996b05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: "939ab60734a4f8fa95feacb55804fa278de28bdeef38e616dc08e44a84adea23"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "2.4.3"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "1.2.1"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "3.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=3.2.3 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,16 +2,16 @@ name: kana_kit
 description: >
   A Dart library for for detecting and transliterating Hiragana, Katakana, and
   Romaji.
-version: 2.0.0
+version: 2.1.0
 repository: https://github.com/jeroen-meijer/kana_kit
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: '>=3.2.3 <4.0.0'
 
 dependencies:
-  equatable: ^2.0.0
+  equatable: ^2.0.5
 
 dev_dependencies:
-  test: 1.16.5
-  test_coverage: 0.5.0
-  very_good_analysis: 1.0.4
+  coverage: ^1.7.2
+  test: ^1.25.1
+  very_good_analysis: ^5.1.0

--- a/test/conversions_test.dart
+++ b/test/conversions_test.dart
@@ -162,8 +162,8 @@ void main() {
       the(input: 'wi', shouldBecome: 'うぃ');
       the(input: 'WI', shouldBecome: 'ウィ');
       the(
-        input: 'ワニカニ AiUeO 鰐蟹 12345 @#\$%',
-        shouldBecome: 'ワニカニ　アいウえオ　鰐蟹　12345　@#\$%',
+        input: r'ワニカニ AiUeO 鰐蟹 12345 @#\$%',
+        shouldBecome: r'ワニカニ　アいウえオ　鰐蟹　12345　@#\$%',
       );
     });
 

--- a/test/models/kana_kit_config_test.dart
+++ b/test/models/kana_kit_config_test.dart
@@ -10,7 +10,7 @@ const romanization = Romanization.hepburn;
 void main() {
   group('KanaKitConfig', () {
     test('props are correct', () {
-      final actual = const KanaKitConfig(
+      final actual = KanaKitConfig(
         passRomaji: passRomaji,
         passKanji: passKanji,
         upcaseKatakana: upcaseKatakana,
@@ -28,7 +28,7 @@ void main() {
     group('constructor', () {});
     group('copyWith', () {
       test(
-        'returns same object with updated passRomaji'
+        'returns same object with updated passRomaji '
         'when passRomaji is provided',
         () {
           const initial = false;
@@ -49,7 +49,7 @@ void main() {
         },
       );
       test(
-        'returns same object with updated passKanji'
+        'returns same object with updated passKanji '
         'when passKanji is provided',
         () {
           const initial = true;
@@ -70,7 +70,7 @@ void main() {
         },
       );
       test(
-        'returns same object with updated upcaseKatakana'
+        'returns same object with updated upcaseKatakana '
         'when upcaseKatakana is provided',
         () {
           const initial = false;

--- a/tool/pre_commit.sh
+++ b/tool/pre_commit.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
 
-echo "Running dartfmt..."
-dartfmt -w .
-echo "Running dartanalyzer..."
-dartanalyzer --fatal-infos --fatal-warnings lib test
-echo "Running codecov..."
+echo "Running dart format..."
+dart format .
+echo "Running dart analyze..."
+dart analyze --fatal-infos --fatal-warnings lib test
+echo "Running coverage..."
 rm -rf ./coverage
-pub run test_coverage
+dart run coverage:test_with_coverage
 lcov --remove ./coverage/lcov.info -o ./coverage/filtered.info\
   '**/*.g.dart' \
   'lib/src/models/romanization/**'
 genhtml -o coverage ./coverage/filtered.info
 open ./coverage/index.html
 echo "Running dry run publish..."
-pub publish --dry-run
+dart pub publish --dry-run
 
 echo ""
 echo "Done."


### PR DESCRIPTION
## 2.1.0
- Change minimum required flutter sdk to `3.2.3`.
- Change dartfmt to dart format.
- Change dartanalyzer to dart analyzer.
- Change test_coverage to coverage.
- Fixed all lint warnings.
- Upgrade all dev dependencies.

## Testing
- Unit tests all passing
- Test coverage at 100%

## Issues
Fixes [Support for dart 3.x #22](https://github.com/jeroen-meijer/kana_kit/issues/22)