### PR TITLE
feat: v2.1.1, loosen dependency constraints for meta and collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.1.1
 
 - Loosen dependency version constraints for better compatibility (thanks to @narumi147 and @14h4i)
-  - `meta`: `^1.16.0` -> `^1.9.1`
-  - `collection`: `^1.19.0` -> `^1.17.1`
+  - `meta`: `^1.16.0` → `^1.9.1`
+  - `collection`: `^1.19.0` → `^1.17.1`
 
 ## 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.1
+
+- Loosen dependency version constraints for better compatibility (thanks to @narumi147 and @14h4i)
+  - `meta`: `^1.16.0` -> `^1.9.1`
+  - `collection`: `^1.19.0` -> `^1.17.1`
+
 ## 2.1.0
 
 - Fix シークヮーサー and シマウヮー conversion edge-cases (thanks to @Moseco and @HighLiuk)

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -10,6 +10,7 @@ words:
   - japanese
   - Mergify
   - Moseco
+  - narumi
   - NNBD
   - Ōsaka
   - pubspec

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
+      sha256: "45cfa8471b89fb6643fe9bf51bd7931a76b8f5ec2d65de4fb176dba8d4f22c77"
       url: "https://pub.dev"
     source: hosted
-    version: "67.0.0"
+    version: "73.0.0"
+  _macros:
+    dependency: transitive
+    description: dart
+    source: sdk
+    version: "0.3.2"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
+      sha256: "4959fec185fe70cce007c57e9ab6983101dbe593d2bf8bbfb4453aaec0cf470a"
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "6.8.0"
   args:
     dependency: transitive
     description:
@@ -37,18 +42,10 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "5bbf32bc9e518d41ec49718e2931cd4527292c9b0c6d2dffcf7fe6b9a8a8cf72"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      sha256: "8e36feea6de5ea69f2199f29cf42a450a855738c498b57c0b980e2d3cca9c362"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
+    version: "2.1.1"
   checks:
     dependency: "direct main"
     description:
@@ -93,10 +90,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.1"
   frontend_server_client:
     dependency: transitive
     description:
@@ -153,6 +150,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  macros:
+    dependency: transitive
+    description:
+      name: macros
+      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2-main.4"
   matcher:
     dependency: transitive
     description:
@@ -173,10 +178,10 @@ packages:
     dependency: transitive
     description:
       name: mime
-      sha256: "801fd0b26f14a4a58ccb09d5892c3fbdeff209594300a542492cf13fba9d247a"
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "2.0.0"
   node_preamble:
     dependency: transitive
     description:
@@ -197,18 +202,18 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "2ad4cddff7f5cc0e2d13069f2a3f7a73ca18f66abd6f5ecf215219cdb3638edb"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.0"
   pool:
     dependency: transitive
     description:
       name: pool
-      sha256: "05955e3de2683e1746222efd14b775df7131139e07695dc8e24650f6b4204504"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
@@ -253,58 +258,58 @@ packages:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      sha256: "8c463326277f68a628abab20580047b419c2ff66756fd0affd451f73f9508c11"
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      sha256: "52de2200bb098de739794c82d09c41ac27b2e42fd7e23cce7b9c74bf653c7296"
+      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.12"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: d5f89a9e52b36240a80282b3dc0667dd36e53459717bb17b8fb102d30496606a
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: f8d9f247e2f9f90e32d1495ff32dac7e4ae34ffa7194c5ff8fcc0fd0e52df774
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: db47e4797198ee601990820437179bb90219f918962318d494ada2b4b11e6f6d
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: dd11571b8a03f7cadcf91ec26a77e02bfbd6bbba2a512924d3116646b4198fc4
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a88162591b02c1f3a3db3af8ce1ea2b374bd75a7bb8d5e353bcfbdc79d719830
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
@@ -333,10 +338,10 @@ packages:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.2"
   very_good_analysis:
     dependency: "direct dev"
     description:
@@ -349,10 +354,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   watcher:
     dependency: transitive
     description:
@@ -365,10 +370,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   web_socket:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: kana_kit
 description: >
   A Dart library for for detecting and transliterating Hiragana, Katakana, and
   Romaji.
-version: 2.1.0
+version: 2.1.1
 repository: https://github.com/jeroen-meijer/kana_kit
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 
 dependencies:
   checks: ^0.3.0
-  collection: ^1.19.0
-  meta: ^1.16.0
+  collection: ^1.17.1
+  meta: ^1.9.1
 
 dev_dependencies:
   coverage: 1.9.2

--- a/tool/pre_commit.sh
+++ b/tool/pre_commit.sh
@@ -1,28 +1,36 @@
 #!/bin/sh
 
-echo "Running dartfmt..."
-dartfmt -w .
-echo "Running dartanalyzer..."
-dartanalyzer --fatal-infos --fatal-warnings lib test
-echo "Running codecov..."
+function print_bold() {
+  echo "\033[1m$1\033[0m"
+}
+
+print_bold "Formatting..."
+fvm dart format lib test
+
+print_bold "Analyzing..."
+fvm dart analyze --fatal-infos --fatal-warnings lib test
+
+print_bold "Running codecov..."
 rm -rf ./coverage
-pub run test_coverage
+
+fvm dart run coverage:test_with_coverage
 lcov --remove ./coverage/lcov.info -o ./coverage/filtered.info\
   '**/*.g.dart' \
   'lib/src/models/romanization/**'
 genhtml -o coverage ./coverage/filtered.info
 open ./coverage/index.html
-echo "Running dry run publish..."
-pub publish --dry-run
 
-echo ""
-echo "Done."
-echo ""
+print_bold "Running dry run publish..."
+fvm dart pub publish --dry-run
+
+print_bold ""
+print_bold "Done."
+print_bold ""
 
 if [ -z "$(git status --porcelain)" ]; then
-  echo "Working directory clean."
+  print_bold "Working directory clean."
   exit 0
 else
-  echo "! Uncommitted changes detected. Please push the new changes to this branch."
+  print_bold "! Uncommitted changes detected. Please push the new changes to this branch."
   exit 1
 fi


### PR DESCRIPTION
# Description

This PR bumps the version to 2.1.1 and does the following:

- Loosen dependency version constraints for better compatibility (thanks to @narumi147 and @14h4i)
  - `meta`: `^1.16.0` → `^1.9.1`
  - `collection`: `^1.19.0` → `^1.17.1`

## Related issues and PRs

Fixes #25